### PR TITLE
Fixed font size when specified in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ PLUGINS_CONFIG = {
         'with_text': True,
         'text_fields': ['name', 'serial'],
         'font': 'ArialMT',
+        'font_size': 12, # If the value is 0 or the line does not exist, then the text is automatically adjusted
         'custom_text': 'Property of SomeCompany\ntel.8.800333554-CALL',
         'text_location': 'up',
         'qr_version': 1,

--- a/netbox_qrcode/template_content.py
+++ b/netbox_qrcode/template_content.py
@@ -50,7 +50,7 @@ class QRCode(PluginTemplateExtension):
             if custom_text:
                 text.append(custom_text)
             text = '\n'.join(text)
-            text_img = get_qr_text(qr_img.size, text, config.get('font'))
+            text_img = get_qr_text(qr_img.size, text, config.get('font'), config.get('font_size', 0))
             qr_with_text = get_concat(qr_img, text_img, config.get('text_location', 'right'))
 
             img = get_img_b64(qr_with_text)

--- a/netbox_qrcode/utilities.py
+++ b/netbox_qrcode/utilities.py
@@ -30,7 +30,7 @@ def get_img_b64(img):
 
 def get_qr_text(max_size, text, font='TahomaBold', font_size=0):
 
-    tmpimg = Image.new('L', max_size, 'white')
+    tmpimg = Image.new('P', max_size, 'white')
     text_too_large = True
 
     #If no Font Size in Config File, then Match the text to the QR Code

--- a/netbox_qrcode/utilities.py
+++ b/netbox_qrcode/utilities.py
@@ -78,7 +78,7 @@ def get_concat(im1, im2, direction='right'):
             'Invalid direction "{}" (must be one of "left", "right", "up", or "down")'.format(direction)
         )
 
-    dst = Image.new('L', (width, height), 'white')
+    dst = Image.new('P', (width, height), 'white')
 
     if direction == 'right' or direction == 'left':
         if im1.height > im2.height:

--- a/netbox_qrcode/utilities.py
+++ b/netbox_qrcode/utilities.py
@@ -28,11 +28,29 @@ def get_img_b64(img):
     return str(base64.b64encode(stream.getvalue()), encoding='ascii')
 
 
-def get_qr_text(max_size, text, font='TahomaBold'):
-    font_size = 56
+def get_qr_text(max_size, text, font='TahomaBold', font_size=0):
+
     tmpimg = Image.new('L', max_size, 'white')
     text_too_large = True
-    while text_too_large:
+
+    #If no Font Size in Config File, then Match the text to the QR Code
+    if font_size == 0:
+
+        font_size = 56
+
+        while text_too_large:
+            file_path = resource_stream(__name__, 'fonts/{}.ttf'.format(font))
+            try:
+                fnt = ImageFont.truetype(file_path, font_size)
+            except Exception:
+                fnt = ImageFont.load_default()
+
+            draw = ImageDraw.Draw(tmpimg)
+            w, h = draw.textsize(text, font=fnt)
+            if w < max_size[0] - 4 and h < max_size[1] - 4:
+                text_too_large = False
+            font_size -= 1
+    else:
         file_path = resource_stream(__name__, 'fonts/{}.ttf'.format(font))
         try:
             fnt = ImageFont.truetype(file_path, font_size)
@@ -41,9 +59,6 @@ def get_qr_text(max_size, text, font='TahomaBold'):
 
         draw = ImageDraw.Draw(tmpimg)
         w, h = draw.textsize(text, font=fnt)
-        if w < max_size[0] - 4 and h < max_size[1] - 4:
-            text_too_large = False
-        font_size -= 1
 
     img = Image.new('L', (w, h), 'white')
     draw = ImageDraw.Draw(img)


### PR DESCRIPTION
If font_size is specified via configuration, then the fixed font size is used.
If the font size is not specified or the value = 0, the previous dynamic behavior will still be executed.

Refers to the Issue: https://github.com/k01ek/netbox-qrcode/issues/11