### PR TITLE
Implement url_template allowing custom url for objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ QR Code. The following values are available:
 is.
 * `qr_border`: Integer (default 4),  controls how many boxes thick the border should be
 (the default is 4, which is the minimum according to the specs).
+* `url_template`: Jinja2 template applied to url with {{ obj }}  as context
 
 ### Per object options
 

--- a/netbox_qrcode/template_content.py
+++ b/netbox_qrcode/template_content.py
@@ -15,7 +15,12 @@ class QRCode(PluginTemplateExtension):
         config = self.context['config']
         obj = self.context['object']
         request = self.context['request']
-        url = request.build_absolute_uri(obj.get_absolute_url())
+        if config.get('url_template'):
+            django_engine = engines["django"]
+            template = django_engine.from_string(config.get('url_template'))
+            url = template.render({'obj': obj})
+        else:
+            url = request.build_absolute_uri(obj.get_absolute_url())
         # get object settings
         obj_cfg = config.get(self.model.replace('dcim.', ''))
         if obj_cfg is None:

--- a/netbox_qrcode/template_content.py
+++ b/netbox_qrcode/template_content.py
@@ -15,19 +15,20 @@ class QRCode(PluginTemplateExtension):
         config = self.context['config']
         obj = self.context['object']
         request = self.context['request']
-        if config.get('url_template'):
-            django_engine = engines["django"]
-            template = django_engine.from_string(config.get('url_template'))
-            url = template.render({'obj': obj})
-        else:
-            url = request.build_absolute_uri(obj.get_absolute_url())
         # get object settings
         obj_cfg = config.get(self.model.replace('dcim.', ''))
         if obj_cfg is None:
             return ''
         # and ovverride default
         config.update(obj_cfg)
-
+        
+        if config.get('url_template'):
+            django_engine = engines["django"]
+            template = django_engine.from_string(config.get('url_template'))
+            url = template.render({'obj': obj})
+        else:
+            url = request.build_absolute_uri(obj.get_absolute_url())
+            
         qr_args = {}
         for k, v in config.items():
             if k.startswith('qr_'):


### PR DESCRIPTION
Allowing users to set a custom url for objects using jinja template. This allow to search object using another key than the object id. 