### PR TITLE
Use new Netbox version identifier. Fixes #93

### DIFF
--- a/netbox_qrcode/template_content.py
+++ b/netbox_qrcode/template_content.py
@@ -67,7 +67,7 @@ class QRCode(PluginTemplateExtension):
         else:
             img = get_img_b64(qr_img)
         try:
-            if version.parse(settings.VERSION).major >= 3:
+            if version.parse(settings.RELEASE.version).major >= 3:
                 return self.render(
                     'netbox_qrcode/qrcode3.html', extra_context={'image': img}
                 )


### PR DESCRIPTION
Netbox deployments using the Netbox Docker image encounter an InvalidVersion error when loading a view (such as device details) that contains the QR code plugin. An example of the error:

> <class 'packaging.version.InvalidVersion'>
>
> Invalid version: '4.2.4-Docker-3.2.0'
>
> Python version: 3.12.3
> NetBox version: 4.2.4-Docker-3.2.0
> Plugins: 
>   netbox_qrcode: 0.0.16
>
> If further assistance is required, please post to the NetBox discussion forum on GitHub.

This pull request implements the same fix I'm seeing elsewhere, such as https://github.com/netbox-community/netbox-topology-views/pull/608