### PR TITLE
feat: add support for NetBox Inventory Assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Netbox QR Code Plugin
 
-[Netbox](https://github.com/netbox-community/netbox) plugin for generate QR codes for objects: Device, Module, Cable, Powerfeed, Powerpanel, Location 
+[Netbox](https://github.com/netbox-community/netbox) plugin to generate QR codes for objects: Device, Module, Cable, Powerfeed, Powerpanel, Location, and NetBox Inventory Assets
 
 This plugin depends on [qrcode](https://github.com/lincolnloop/python-qrcode) and [Pillow](https://github.com/python-pillow/Pillow) python library
 

--- a/netbox_qrcode/__init__.py
+++ b/netbox_qrcode/__init__.py
@@ -105,7 +105,14 @@ class QRCodeConfig(PluginConfig):
         },   
 
         'module': {
-        },   
+        },
+        
+        'asset': {
+            'text_fields': [
+                'name',
+                'asset_tag',
+                'serial']
+        },
         'logo': '',
     }
 

--- a/netbox_qrcode/template_content.py
+++ b/netbox_qrcode/template_content.py
@@ -4,6 +4,13 @@ from django.core.exceptions import ObjectDoesNotExist
 from netbox.plugins import PluginTemplateExtension
 from .template_content_functions import create_text, create_url, config_for_modul, create_QRCode
 
+# Check if netbox-inventory is available
+try:
+    import netbox_inventory
+    INVENTORY_AVAILABLE = True
+except ImportError:
+    INVENTORY_AVAILABLE = False
+
 # ******************************************************************************************
 # Contains the main functionalities of the plugin and thus creates the content for the 
 # individual modules, e.g: Device, Rack etc.
@@ -160,17 +167,21 @@ class ModuleQRCode(QRCode):
     def right_page(self):
         return self.Create_PluginContent()
 
+
 ##################################
 # Other plugins support
 
-# Commenting out (for now) - make this work on core models first.
-# Class for creating a QR code for the Plugin: Netbox-Inventory (https://github.com/ArnesSI/netbox-inventory)
-#class Plugin_Netbox_Inventory(QRCode):
-#    models = ()'netbox_inventory.asset' # Info for Netbox in which model the plugin should be integrated.
-#
-#    def right_page(self):
-#        return self.Create_PluginContent()
+# Class for Netbox-Inventory Plugin
+class AssetQRCode(QRCode):
+    models = ('netbox_inventory.asset')
+
+    def right_page(self):
+        return self.Create_PluginContent()
+
 
 # Connects Netbox Core with the plug-in classes
-# Removed , Plugin_Netbox_Inventory]
 template_extensions = [DeviceQRCode, ModuleQRCode, RackQRCode, CableQRCode, LocationQRCode, PowerFeedQRCode, PowerPanelQRCode]
+
+# Conditionally add AssetQRCode if inventory integration is available
+if INVENTORY_AVAILABLE:
+    template_extensions.append(AssetQRCode)

--- a/netbox_qrcode/template_content_functions.py
+++ b/netbox_qrcode/template_content_functions.py
@@ -24,7 +24,9 @@ def config_for_modul(parentSelf, labelDesignNo):
 
     # Collect the QR code plugin configuration for the specific object such as device, rack etc.
     # and overwrite the default configuration fields.
-    obj_cfg = config.get(parentSelf.models[0].replace('dcim.', '') + confModulsufix) # get spezific object settings
+    # TODO: Replace with a model name map instead
+    model_name = parentSelf.models[0].replace('dcim.', '').replace('netbox_inventory.', '')
+    obj_cfg = config.get(model_name + confModulsufix) # get spezific object settings
     
     if obj_cfg is not None: 
         config.update(obj_cfg) # Ovverride default confiv Values


### PR DESCRIPTION
I want to add support for the NetBox Inventory Plugin, as I have more spare parts than complete servers. Many of these parts look identical but are programmed differently, come from different vendors, or don’t have any labels. Adding QR codes to these parts would help link them to servers in case of a new build or replacement. This way, someone only needs to scan the QR code to identify the item.