### PR TITLE
feat: Enable dynamic label width

### DIFF
--- a/netbox_qrcode/templates/netbox_qrcode/qrcode3.html
+++ b/netbox_qrcode/templates/netbox_qrcode/qrcode3.html
@@ -36,6 +36,7 @@
         max-width: {{label_width}};
         background-color: WhiteSmoke;
         outline: 1px solid black;
+        display: inline-block;
     }
 </style>
  


### PR DESCRIPTION
Hello,

we would like to use this plugin and also will do so, but one aspect is a bit unfortunate: The need for a fixed label width. Okay, technically, you can set "auto" to "label_width", but because the div container is by default "display:block", the label extends fully.

This very little PR simply adds a CSS line to make the container "inline-block". By setting "label_width" to "auto", the label will now adjust automatically. (Of course, you have to set a margin-right by using label_edge_* to avoid text next to the label border).