### PR TITLE
Adding support for overlaying an image over the QR code.

### DIFF
--- a/netbox_qrcode/__init__.py
+++ b/netbox_qrcode/__init__.py
@@ -56,7 +56,7 @@ class QRCodeConfig(PluginConfig):
         ################################## 
         # QR Overlay
         'qr_overlay': None,
-        'qr_overlay_brightness_enhance': None,
+        'qr_overlay_alpha': None,
         
         ################################## 
         # Label Layout

--- a/netbox_qrcode/__init__.py
+++ b/netbox_qrcode/__init__.py
@@ -51,6 +51,12 @@ class QRCodeConfig(PluginConfig):
         'qr_error_correction': 0,
         'qr_box_size': 4,
         'qr_border': 0,
+
+
+        ################################## 
+        # QR Overlay
+        'qr_overlay': None,
+        'qr_overlay_brightness_enhance': None,
         
         ################################## 
         # Label Layout

--- a/netbox_qrcode/template_content.py
+++ b/netbox_qrcode/template_content.py
@@ -59,6 +59,8 @@ class QRCode(PluginTemplateExtension):
                                                                     'font_weight': config.get('font_weight'),
                                                                     'font_color': config.get('font_color'),
                                                                     'with_qr': config.get('with_qr'),
+                                                                    'qr_overlay': config.get('qr_overlay'),
+                                                                    'qr_overlay_brightness_enhance': config.get('qr_overlay_brightness_enhance'),
                                                                     'label_qr_width': config.get('label_qr_width'),
                                                                     'label_qr_height': config.get('label_qr_height'),
                                                                     'label_qr_text_distance': config.get('label_qr_text_distance'),

--- a/netbox_qrcode/template_content.py
+++ b/netbox_qrcode/template_content.py
@@ -60,7 +60,7 @@ class QRCode(PluginTemplateExtension):
                                                                     'font_color': config.get('font_color'),
                                                                     'with_qr': config.get('with_qr'),
                                                                     'qr_overlay': config.get('qr_overlay'),
-                                                                    'qr_overlay_brightness_enhance': config.get('qr_overlay_brightness_enhance'),
+                                                                    'qr_overlay_alpha': config.get('qr_overlay_alpha'),
                                                                     'label_qr_width': config.get('label_qr_width'),
                                                                     'label_qr_height': config.get('label_qr_height'),
                                                                     'label_qr_text_distance': config.get('label_qr_text_distance'),

--- a/netbox_qrcode/template_content_functions.py
+++ b/netbox_qrcode/template_content_functions.py
@@ -45,12 +45,15 @@ def create_QRCode(text, config):
     overlay = None
     overlay_brightness_enhance = None
     for k, v in config.items():
-        if k.startswith("qr_") and k != "qr_overlay":
+        if k.startswith("qr_") and not k.startswith("qr_overlay"):
             qr_args[k.replace("qr_", "")] = v
         if k == "qr_overlay":
             overlay = v
         if k == "qr_overlay_brightness_enhance":
-            overlay_brightness_enhance = v
+            if v:
+                overlay_brightness_enhance = float(v)
+            else:
+                overlay_brightness_enhance = None
 
     # Create a QR code
     qrCode = get_qr(text, overlay, overlay_brightness_enhance, **qr_args)

--- a/netbox_qrcode/template_content_functions.py
+++ b/netbox_qrcode/template_content_functions.py
@@ -43,20 +43,20 @@ def create_QRCode(text, config):
     # These are required to generate the QR code.
     qr_args = {}
     overlay = None
-    overlay_brightness_enhance = None
+    overlay_alpha = None
     for k, v in config.items():
         if k.startswith("qr_") and not k.startswith("qr_overlay"):
             qr_args[k.replace("qr_", "")] = v
         if k == "qr_overlay":
             overlay = v
-        if k == "qr_overlay_brightness_enhance":
+        if k == "qr_overlay_alpha":
             if v:
-                overlay_brightness_enhance = float(v)
+                overlay_alpha = float(v)
             else:
-                overlay_brightness_enhance = None
+                overlay_alpha = None
 
     # Create a QR code
-    qrCode = get_qr(text, overlay, overlay_brightness_enhance, **qr_args)
+    qrCode = get_qr(text, overlay, overlay_alpha, **qr_args)
     return get_img_b64(qrCode)
 
 ##################################

--- a/netbox_qrcode/template_content_functions.py
+++ b/netbox_qrcode/template_content_functions.py
@@ -39,18 +39,22 @@ def config_for_modul(parentSelf, labelDesignNo):
 #   text: Text for QR-Code
 #   config: From the Netbox configuration file
 def create_QRCode(text, config):
-
     # Collect the configuration entries that begin with "qr_.
     # These are required to generate the QR code.
     qr_args = {}
+    overlay = None
+    overlay_brightness_enhance = None
     for k, v in config.items():
-        if k.startswith('qr_'):
-            qr_args[k.replace('qr_', '')] = v
+        if k.startswith("qr_") and k != "qr_overlay":
+            qr_args[k.replace("qr_", "")] = v
+        if k == "qr_overlay":
+            overlay = v
+        if k == "qr_overlay_brightness_enhance":
+            overlay_brightness_enhance = v
 
     # Create a QR code
-    qrCode = get_qr(text, **qr_args)
+    qrCode = get_qr(text, overlay, overlay_brightness_enhance, **qr_args)
     return get_img_b64(qrCode)
-
 
 ##################################
 # Create URL for QR code

--- a/netbox_qrcode/utilities.py
+++ b/netbox_qrcode/utilities.py
@@ -1,6 +1,7 @@
 import base64
 import qrcode
 from io import BytesIO
+from PIL import Image, ImageOps, ImageEnhance
 
 # ******************************************************************************************
 # Includes useful tools to create the content.
@@ -12,12 +13,19 @@ from io import BytesIO
 # Parameter:
 #   text: Text to be included in the QR code.
 #   **kwargs: List of parameters which properties the QR code should have. (e.g. version, box_size, error_correction, border etc.)
-def get_qr(text, **kwargs):
+def get_qr(
+    text,
+    overlay: str | None = None,
+    overlay_brightness_enhance: float | None = None,
+    **kwargs,
+):
     qr = qrcode.QRCode(**kwargs)
     qr.add_data(text)
     qr.make(fit=True)
     img = qr.make_image()
     img = img.get_image()
+    if overlay:
+        img = texture_qr_modules(img, overlay, overlay_brightness_enhance)
     return img
 
 ##################################          
@@ -29,3 +37,38 @@ def get_img_b64(img):
     stream = BytesIO()
     img.save(stream, format='png')
     return str(base64.b64encode(stream.getvalue()), encoding='ascii')
+
+##################################
+# Replace the QR Code's black modules with pixels from 'texture_path',
+# leaving white background untouched.
+# --------------------------------
+# Parameter:
+#   qr_img: Generated QR code
+#   texture_path: Path to overlay image
+#   brightness_enhance: Float of 0-1 to increase brightness
+def texture_qr_modules(
+    qr_img: Image.Image,
+    texture_path: str,
+    overlay_brightness_enhance: float | None = None,
+) -> Image.Image:
+    """
+    Replace the QR Code's black modules with pixels from 'texture_path',
+    leaving white background untouched.
+    """
+
+    qr_rgb = qr_img.convert("RGB")
+
+    inv = ImageOps.invert(qr_rgb.convert("L"))
+    mask = inv.point(lambda p: 255 if p > 128 else 0)
+
+    texture = Image.open(texture_path).convert("RGB").resize(qr_rgb.size, Image.LANCZOS)
+
+    if overlay_brightness_enhance:
+        texture = ImageEnhance.Brightness(texture).enhance(overlay_brightness_enhance)
+
+    white = Image.new("RGB", qr_rgb.size, (255, 255, 255))
+    textured_modules = Image.composite(texture, white, mask)
+
+    return textured_modules
+
+

--- a/netbox_qrcode/utilities.py
+++ b/netbox_qrcode/utilities.py
@@ -7,7 +7,8 @@ from PIL import Image, ImageOps, ImageEnhance
 # Includes useful tools to create the content.
 # ******************************************************************************************
 
-##################################          
+
+##################################
 # Creates a QR code as an image.: https://pypi.org/project/qrcode/3.0/
 # --------------------------------
 # Parameter:
@@ -16,7 +17,7 @@ from PIL import Image, ImageOps, ImageEnhance
 def get_qr(
     text,
     overlay: str | None = None,
-    overlay_brightness_enhance: float | None = None,
+    overlay_alpha: float | None = None,
     **kwargs,
 ):
     qr = qrcode.QRCode(**kwargs)
@@ -25,18 +26,20 @@ def get_qr(
     img = qr.make_image()
     img = img.get_image()
     if overlay:
-        img = texture_qr_modules(img, overlay, overlay_brightness_enhance)
+        img = texture_qr_modules(img, overlay, overlay_alpha)
     return img
 
-##################################          
+
+##################################
 # Converts an image to Base64
 # --------------------------------
 # Parameter:
 #   img: Image file
 def get_img_b64(img):
     stream = BytesIO()
-    img.save(stream, format='png')
-    return str(base64.b64encode(stream.getvalue()), encoding='ascii')
+    img.save(stream, format="png")
+    return str(base64.b64encode(stream.getvalue()), encoding="ascii")
+
 
 ##################################
 # Replace the QR Code's black modules with pixels from 'texture_path',
@@ -49,11 +52,11 @@ def get_img_b64(img):
 def texture_qr_modules(
     qr_img: Image.Image,
     texture_path: str,
-    overlay_brightness_enhance: float | None = None,
+    overlay_alpha: float | None = None,
 ) -> Image.Image:
     """
     Replace the QR Code's black modules with pixels from 'texture_path',
-    leaving white background untouched.
+    leaving white background untouched. Transparent pixels in the texture are not affected.
     """
 
     qr_rgb = qr_img.convert("RGB")
@@ -61,14 +64,25 @@ def texture_qr_modules(
     inv = ImageOps.invert(qr_rgb.convert("L"))
     mask = inv.point(lambda p: 255 if p > 128 else 0)
 
-    texture = Image.open(texture_path).convert("RGB").resize(qr_rgb.size, Image.LANCZOS)
+    # Load texture in RGBA to detect transparent pixels
+    texture = (
+        Image.open(texture_path).convert("RGBA").resize(qr_rgb.size, Image.LANCZOS)
+    )
 
-    if overlay_brightness_enhance:
-        texture = ImageEnhance.Brightness(texture).enhance(overlay_brightness_enhance)
+    # Extract alpha channel
+    alpha = texture.split()[3]
 
+    # Adjust alpha transparency if overlay_alpha is provided
+    if overlay_alpha is not None:
+        alpha = alpha.point(lambda p: int(p * overlay_alpha))
+
+    texture_rgb = texture.convert("RGB")
+
+    # Composite texture over the original QR using alpha channel
+    result = Image.composite(texture_rgb, qr_rgb, alpha)
+
+    # Now apply the QR mask to keep white background, only allowing texture in black modules
     white = Image.new("RGB", qr_rgb.size, (255, 255, 255))
-    textured_modules = Image.composite(texture, white, mask)
+    textured_modules = Image.composite(result, white, mask)
 
     return textured_modules
-
-


### PR DESCRIPTION
This PR adds support for adding image overlays over the generated QR code.

<img width="378" height="233" alt="image" src="https://github.com/user-attachments/assets/3a49f7f0-3d22-4325-96be-e1ea89d1dd99" />

It adds two more config options, qr_overlay and qr_overlay_alpha

if qr_overlay is provided and points to an image file, it will overlay the image over the QR code's black pixels, leaving the white pixels alone.

